### PR TITLE
Fix do_lower_case

### DIFF
--- a/processors/ner_seq.py
+++ b/processors/ner_seq.py
@@ -90,6 +90,9 @@ def convert_examples_to_features(examples,label_list,max_seq_length,tokenizer,
             tokens = tokens[: (max_seq_length - special_tokens_count)]
             label_ids = label_ids[: (max_seq_length - special_tokens_count)]
 
+        if tokenizer.do_lower_case:
+            tokens = [x.lower() for x in tokens]
+
         # The convention in BERT is:
         # (a) For sequence pairs:
         #  tokens:   [CLS] is this jack ##son ##ville ? [SEP] no it is not . [SEP]

--- a/processors/ner_span.py
+++ b/processors/ner_span.py
@@ -97,6 +97,10 @@ def convert_examples_to_features(examples,label_list,max_seq_length,tokenizer,
             tokens = tokens[: (max_seq_length - special_tokens_count)]
             start_ids = start_ids[: (max_seq_length - special_tokens_count)]
             end_ids = end_ids[: (max_seq_length - special_tokens_count)]
+
+        if tokenizer.do_lower_case:
+            tokens = [x.lower() for x in tokens]
+
         # The convention in BERT is:
         # (a) For sequence pairs:
         #  tokens:   [CLS] is this jack ##son ##ville ? [SEP] no it is not . [SEP]
@@ -248,5 +252,3 @@ ner_processors = {
     "cner": CnerProcessor,
     'cluener':CluenerProcessor
 }
-
-


### PR DESCRIPTION
`do_lower_case`参数用于判断是否对输入文本小写，传递给tokenizer。

```python
tokenizer = tokenizer_class.from_pretrained(args.model_name_or_path, do_lower_case=args.do_lower_case,)
```

参数在`tokenizer.tokenize`方法中发挥作用，本项目中直接使用了`tokenizer.convert_tokens_to_ids`方法，实际上并没有起作用，因此需要手动处理。

```python
def convert_examples_to_features(...):
    ...
    if tokenizer.do_lower_case:
        tokens = [x.lower() for x in tokens]
    ...
    input_ids = tokenizer.convert_tokens_to_ids(tokens)
```
